### PR TITLE
Implement cohend_group utility

### DIFF
--- a/cohend_group.ipynb
+++ b/cohend_group.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Función `cohend_group`\n",
+    "Implementación en un notebook para Google Colab.\n",
+    "Permite seleccionar las variables pre y post y el método para calcular el tamaño del efecto de Cohen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Instalar dependencias en Colab (si es necesario)\n",
+    "!pip install -q xlsxwriter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from scipy import stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def cohend_group(df: pd.DataFrame, varlist: list[str], group: str, method: str = 'dz') -> pd.DataFrame:\n",
+    "    \"\"\"Calcula el tamaño del efecto de Cohen d por nivel de un grupo.\n",
+    "    Los valores 2 representan 'logro'. Se calcula la proporción de logros en las\n",
+    "    variables PRE y POST, su diferencia y el tamaño de efecto según el método\n",
+    "    indicado. También se exporta el resultado a un archivo Excel.\n",
+    "    \"\"\"\n",
+    "    # 1. Validaciones iniciales\n",
+    "    if group not in df.columns:\n",
+    "        raise ValueError(f'La columna de grupo {group!r} no existe en el DataFrame')\n",
+    "    if len(varlist) % 2 != 0:\n",
+    "        raise ValueError(\"'varlist' debe contener un número par de variables\")\n",
+    "    for col in varlist:\n",
+    "        if col not in df.columns:\n",
+    "            raise ValueError(f'La columna {col!r} no existe en el DataFrame')\n",
+    "\n",
+    "    # 2. Separar en listas PRE y POST\n",
+    "    mid = len(varlist) // 2\n",
+    "    prevars = varlist[:mid]\n",
+    "    postvars = varlist[mid:]\n",
+    "\n",
+    "    dfc = df.copy()\n",
+    "    # 3. Asegurar valores numéricos\n",
+    "    dfc[prevars + postvars] = dfc[prevars + postvars].apply(pd.to_numeric, errors='coerce')\n",
+    "\n",
+    "    # 4. Proporciones y diferencia por fila\n",
+    "    dfc['tpre'] = (dfc[prevars] == 2).mean(axis=1)\n",
+    "    dfc['tpost'] = (dfc[postvars] == 2).mean(axis=1)\n",
+    "    dfc['dif'] = dfc['tpost'] - dfc['tpre']\n",
+    "\n",
+    "    resultados = []\n",
+    "    # 5. Iterar por cada nivel de grupo\n",
+    "    for nivel in dfc[group].astype(str).unique():\n",
+    "        sub = dfc[dfc[group].astype(str) == str(nivel)]\n",
+    "        sub = sub.dropna(subset=['tpre', 'tpost'])\n",
+    "        N = len(sub)\n",
+    "        if N == 0:\n",
+    "            continue\n",
+    "        m_pre = sub['tpre'].mean()\n",
+    "        m_post = sub['tpost'].mean()\n",
+    "        m_diff = sub['dif'].mean()\n",
+    "        sd_pre = sub['tpre'].std(ddof=1)\n",
+    "        sd_post = sub['tpost'].std(ddof=1)\n",
+    "        sd_diff = sub['dif'].std(ddof=1)\n",
+    "        r_pp = sub['tpre'].corr(sub['tpost'])\n",
+    "\n",
+    "        if method == 'dz':\n",
+    "            denom = sd_diff\n",
+    "        elif method == 'dav':\n",
+    "            denom = (sd_pre + sd_post) / 2\n",
+    "        elif method == 'drm':\n",
+    "            denom = np.sqrt(sd_pre**2 + sd_post**2 - 2 * r_pp * sd_pre * sd_post)\n",
+    "        else:\n",
+    "            raise ValueError(\"method debe ser 'dz', 'dav' o 'drm'\")\n",
+    "\n",
+    "        d_cohen = m_diff / denom if denom else np.nan\n",
+    "\n",
+    "        if N >= 2:\n",
+    "            t_res = stats.ttest_rel(sub['tpost'], sub['tpre'], nan_policy='omit')\n",
+    "            p_value = t_res.pvalue\n",
+    "        else:\n",
+    "            p_value = np.nan\n",
+    "\n",
+    "        if pd.isna(d_cohen):\n",
+    "            magnitude = 'NA'\n",
+    "            symbol = ''\n",
+    "        elif abs(d_cohen) >= 0.80:\n",
+    "            magnitude = 'GRANDE'\n",
+    "            symbol = '\u2605\u2605\u2605'\n",
+    "        elif abs(d_cohen) >= 0.50:\n",
+    "            magnitude = 'MEDIANO'\n",
+    "            symbol = '\u2605\u2605'\n",
+    "        elif abs(d_cohen) >= 0.20:\n",
+    "            magnitude = 'PEQUEÑO'\n",
+    "            symbol = '\u2605'\n",
+    "        else:\n",
+    "            magnitude = 'TRIVIAL'\n",
+    "            symbol = ''\n",
+    "\n",
+    "        resultados.append({\n",
+    "            'grupo': nivel,\n",
+    "            'N': N,\n",
+    "            'm_pre': m_pre,\n",
+    "            'm_post': m_post,\n",
+    "            'm_diff': m_diff,\n",
+    "            'd_cohen': d_cohen,\n",
+    "            'p_value': p_value,\n",
+    "            'magnitude': magnitude,\n",
+    "            'symbol': symbol\n",
+    "        })\n",
+    "\n",
+    "    result_df = pd.DataFrame(resultados)\n",
+    "    filename = 'cohend_resultados.xlsx'\n",
+    "    titulo = f\"Cohen d – Variables: {', '.join(prevars)}, {', '.join(postvars)} (método={method})\"\n",
+    "    with pd.ExcelWriter(filename, engine='xlsxwriter') as writer:\n",
+    "        result_df.to_excel(writer, sheet_name='resultados', startrow=2, index=False)\n",
+    "        writer.sheets['resultados'].write('A1', titulo)\n",
+    "    print(f'Archivo guardado: {filename}')\n",
+    "    return result_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seleccionar variables y método\n",
+    "Modifica las siguientes celdas para elegir las variables PRE y POST y el método para calcular d."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Listado de columnas disponibles en df\n",
+    "list(df.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Editar manualmente la lista de variables (mitad PRE, mitad POST)\n",
+    "varlist = ['ce_p1', 'ce_p2', 'cs_i1_p1', 'cs_i1_p2']\n",
+    "# Método para el denominador: 'dz', 'dav' o 'drm'\n",
+    "method = 'dav'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "resultados = cohend_group(df, varlist, group='macro', method=method)\n",
+    "resultados"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cohend_group.py
+++ b/cohend_group.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Funcion para calcular el tamanio del efecto de Cohen d por grupo.
+
+Requisitos:
+- pandas, numpy, scipy
+
+Ejemplo de uso al final del archivo.
+"""
+import pandas as pd
+import numpy as np
+from scipy import stats
+
+def cohend_group(
+    df: pd.DataFrame,
+    varlist: list[str],
+    group: str,
+    method: str = "dz"
+) -> pd.DataFrame:
+    """Calcula Cohen d para variables binarias pre y post por grupo.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame con datos.
+    varlist : list[str]
+        Lista de nombres de columnas PRE+POST en orden.
+    group : str
+        Nombre de la columna de grupo.
+    method : str, optional
+        Metodo para el denominador ("dz", "dav" o "drm"), por defecto "dz".
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame con resultados por grupo.
+    """
+
+    # 1. Validaciones iniciales
+    if group not in df.columns:
+        raise ValueError(f"La columna de grupo '{group}' no existe en el DataFrame")
+    if len(varlist) % 2 != 0:
+        raise ValueError("'varlist' debe contener un numero par de variables")
+    for col in varlist:
+        if col not in df.columns:
+            raise ValueError(f"La columna '{col}' no existe en el DataFrame")
+
+    # 2. Dividir en pre y post
+    mid = len(varlist) // 2
+    prevars = varlist[:mid]
+    postvars = varlist[mid:]
+
+    df_copy = df.copy()
+    # 3. Convertir a numerico si es necesario
+    df_copy[prevars + postvars] = df_copy[prevars + postvars].apply(
+        pd.to_numeric, errors="coerce"
+    )
+
+    # 4. Calculos de proporciones y diferencia por registro
+    df_copy["tpre"] = (df_copy[prevars] == 2).mean(axis=1)
+    df_copy["tpost"] = (df_copy[postvars] == 2).mean(axis=1)
+    df_copy["dif"] = df_copy["tpost"] - df_copy["tpre"]
+
+    resultados = []
+
+    # 5. Iterar por cada nivel de grupo
+    for nivel in df_copy[group].astype(str).unique():
+        sub = df_copy[df_copy[group].astype(str) == str(nivel)]
+        sub = sub.dropna(subset=["tpre", "tpost"])
+        N = len(sub)
+        if N == 0:
+            continue
+        m_pre = sub["tpre"].mean()
+        m_post = sub["tpost"].mean()
+        m_diff = sub["dif"].mean()
+        sd_pre = sub["tpre"].std(ddof=1)
+        sd_post = sub["tpost"].std(ddof=1)
+        sd_diff = sub["dif"].std(ddof=1)
+        r_pp = sub["tpre"].corr(sub["tpost"])  # puede ser NaN con N<2
+
+        if method == "dz":
+            denom = sd_diff
+        elif method == "dav":
+            denom = (sd_pre + sd_post) / 2
+        elif method == "drm":
+            denom = np.sqrt(sd_pre ** 2 + sd_post ** 2 - 2 * r_pp * sd_pre * sd_post)
+        else:
+            raise ValueError("method debe ser 'dz', 'dav' o 'drm'")
+
+        d_cohen = m_diff / denom if denom and denom != 0 else np.nan
+
+        if N >= 2:
+            t_res = stats.ttest_rel(sub["tpost"], sub["tpre"], nan_policy="omit")
+            p_value = t_res.pvalue
+        else:
+            p_value = np.nan
+
+        # Clasificacion de magnitud
+        if pd.isna(d_cohen):
+            magnitude = "NA"
+            symbol = ""
+        elif abs(d_cohen) >= 0.80:
+            magnitude = "GRANDE"
+            symbol = "★★★"
+        elif abs(d_cohen) >= 0.50:
+            magnitude = "MEDIANO"
+            symbol = "★★"
+        elif abs(d_cohen) >= 0.20:
+            magnitude = "PEQUEÑO"
+            symbol = "★"
+        else:
+            magnitude = "TRIVIAL"
+            symbol = ""
+
+        resultados.append({
+            "grupo": nivel,
+            "N": N,
+            "m_pre": m_pre,
+            "m_post": m_post,
+            "m_diff": m_diff,
+            "d_cohen": d_cohen,
+            "p_value": p_value,
+            "magnitude": magnitude,
+            "symbol": symbol,
+        })
+
+    result_df = pd.DataFrame(resultados)
+
+    # 7. Exportar a Excel
+    filename = "cohend_resultados.xlsx"
+    titulo = (
+        f"Cohen d – Variables: {', '.join(prevars)}, {', '.join(postvars)} (método={method})"
+    )
+    with pd.ExcelWriter(filename, engine="xlsxwriter") as writer:
+        result_df.to_excel(writer, sheet_name="resultados", startrow=2, index=False)
+        worksheet = writer.sheets["resultados"]
+        worksheet.write("A1", titulo)
+
+    print(f"Archivo guardado: {filename}")
+
+    return result_df
+
+# Ejemplo minimo de uso
+# varlist de variables pre y post
+varlist_ejemplo = ["ce_p1", "ce_p2", "cs_i1_p1", "cs_i1_p2"]
+# Llamada a la funcion
+# resultados = cohend_group(df, varlist=varlist_ejemplo, group="macro", method="dav")
+# print(resultados)


### PR DESCRIPTION
## Summary
- add `cohend_group.py` with function to compute Cohen's d for paired binary variables by group
- include Excel export and minimal usage example
- add `cohend_group.ipynb` notebook to run the function interactively

## Testing
- `python -m py_compile cohend_group.py`


------
https://chatgpt.com/codex/tasks/task_e_687b2a413070832d914d2d504f0e6632